### PR TITLE
chore(services): error linter

### DIFF
--- a/Resources/services.yml
+++ b/Resources/services.yml
@@ -6,5 +6,5 @@ services:
     monolog.handler.fluent:
         class: FluentHandlerBundle\Service\FluentHandlerService
         arguments: ['@fluent.logger']
-        calls: 
+        calls:
             - [setChannel, ['%fluent_handler.channel%']]


### PR DESCRIPTION
# Description

```
[Symfony\Component\DependencyInjection\Exception\InvalidArgumentException]   
The file "/usr/src/app/vendor/lemonde/php-fluent-handler-bundle/DependencyInjection/../Resources/services.yml" does not contain valid YAML.  
```           
                                                                               
```
[Symfony\Component\Yaml\Exception\ParseException]  
Unable to parse at line 9 (near "calls: "). 
```

# Spécification technique

# Recette

# Dépendances
