### PR TITLE
chore/space-in-yaml(update): supprime l'espace en trop car symfony/yaml > 3.2 devient strict avec cela

### DIFF
--- a/Resources/services.yml
+++ b/Resources/services.yml
@@ -6,5 +6,5 @@ services:
     monolog.handler.fluent:
         class: FluentHandlerBundle\Service\FluentHandlerService
         arguments: ['@fluent.logger']
-        calls: 
+        calls:
             - [setChannel, ['%fluent_handler.channel%']]


### PR DESCRIPTION

# Description
Supprime l'espace en trop car symfony/yaml > 3.2 devient strict avec cela
Cela est en vu de la mise à jour vers Symfony 3.3

# Spécification technique
1 espace supprimer

# Recette
Aucune

# Dépendances
Aucune